### PR TITLE
feat: Bifurcated MFN and AFN Item to single Item

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -334,9 +334,13 @@ class AmazonRepository:
 					if not item_qty:
 						item_qty = 1
 					item_rate = item_amount/item_qty
+					item_code = self.get_item_code(order_item)
+					actual_item = frappe.db.get_value("Item", item_code, "actual_item")
+					if actual_item:
+						item_code = actual_item
 					final_order_items.append(
 						{
-							"item_code": self.get_item_code(order_item),
+							"item_code": item_code,
 							"item_name": order_item.get("SellerSKU"),
 							"description": order_item.get("Title"),
 							"rate": item_rate,
@@ -603,7 +607,7 @@ class AmazonRepository:
 				if not frappe.db.exists("Sales Invoice", { "amazon_order_id": order_id, "docstatus":1, "is_return":0 }):
 					failed_sync_record = frappe.new_doc('Amazon Failed Sync Record')
 					failed_sync_record.amazon_order_id = order_id
-					failed_sync_record.remarks = 'Failed to create return Sales Invoice, Not able to find any Sales Invoice with this Amazon Order ID. Sales Order ID : {0}'.format(so)
+					failed_sync_record.remarks = 'Failed to create return Sales Invoice, Not able to find any Sales Invoice with this Amazon Order ID. Sales Order ID : {0}'.format(so_id)
 					failed_sync_record.payload = refund
 					if refund.get("posting_date"):
 						failed_sync_record.posting_date = dateutil.parser.parse(refund.get("posting_date")).strftime("%Y-%m-%d")

--- a/eseller_suite/setup.py
+++ b/eseller_suite/setup.py
@@ -60,6 +60,13 @@ def get_item_custom_fields():
 				"unique": 1,
 				"read_only": 1,
 				"no_copy": 1
+			},
+			{
+				"fieldname": "actual_item",
+				"fieldtype": "Link",
+				"options": "Item",
+				"label": "Actual Item",
+				"insert_after": "item_name",
 			}
 		]
 	}


### PR DESCRIPTION
## Feature description
There are cases where the same Item will have AFN and MFN. To handle this, we will add a reference to the actual item so that the actual will be used wherever the item is referenced.

## Solution description
- Added a custom field on Item Master, Actual Item, Link to Item
- On Creation of Sales Order from Amazon APIs, while finding Item with Amazon Item Code, checked whether the Item has any actual item. If item exists, then the item will be the actual item. Otherwise, the fetched item will be used.

## Issue fixes
- Fixed an issue with a non-existing variable

## Output screenshots
![image](https://github.com/user-attachments/assets/f71ad0a0-7375-4fa7-bf7b-cafd5019e31e)
![image](https://github.com/user-attachments/assets/796cd368-1a78-436f-8967-6314bcfa8b96)

## Areas affected and ensured
Amazon Repository
Item (customisation)

## Is there any existing behavior change of other features due to this code change?
Yes, Items with actual item referenced in it will have the actual item used in so, si etc

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
