### PR TITLE
chore: set customer name to be the order ID

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -368,13 +368,7 @@ class AmazonRepository:
 
 	def create_sales_order(self, order) -> str | None:
 		def create_customer(order) -> str:
-			order_customer_name = ""
-			buyer_info = order.get("BuyerInfo")
-
-			if buyer_info and buyer_info.get("BuyerEmail"):
-				order_customer_name = buyer_info.get("BuyerEmail")
-			else:
-				order_customer_name = f"Buyer - {order.get('AmazonOrderId')}"
+			order_customer_name = order.get('AmazonOrderId', "")
 
 			existing_customer_name = frappe.db.get_value(
 				"Customer", filters={"name": order_customer_name}, fieldname="name"


### PR DESCRIPTION
## Feature description
Customer Name must be the Order ID they are created against

## Solution description
Changed the customer creation code to set customer name as the order ID

## Output screenshots
![image](https://github.com/user-attachments/assets/5b15c90b-2616-40c5-9a93-0d77b718a06e)

## Areas affected and ensured
Customer Creation 

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
