### PR TITLE
feat: daily scheduler and amazon state mapping config

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -32,7 +32,8 @@
   "enable_sync",
   "max_retry_limit",
   "create_item_if_not_exists",
-  "is_old_data_migrated"
+  "is_old_data_migrated",
+  "map_state_data"
  ],
  "fields": [
   {
@@ -221,10 +222,16 @@
    "fieldname": "sync_selected_date_only",
    "fieldtype": "Check",
    "label": "Sync Selected Date Only"
+  },
+  {
+   "default": "0",
+   "fieldname": "map_state_data",
+   "fieldtype": "Check",
+   "label": "Map State Data"
   }
  ],
  "links": [],
- "modified": "2024-09-11 12:29:18.795711",
+ "modified": "2024-12-02 16:12:58.741537",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon SP API Settings",

--- a/eseller_suite/hooks.py
+++ b/eseller_suite/hooks.py
@@ -143,9 +143,9 @@ scheduler_events = {
 # 	"all": [
 # 		"eseller_suite.tasks.all"
 # 	],
-# 	"daily": [
-# 		"eseller_suite.tasks.daily"
-# 	],
+	"daily": [
+		"eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_sp_api_settings.schedule_get_order_details_daily"
+	],
 	"hourly": [
 		"eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_sp_api_settings.schedule_get_order_details",
 	],


### PR DESCRIPTION
## Feature description
- A daily scheduler to ensure that data from the previous day will be synced properly
- Making amazon state mapping optional

## Areas affected and ensured
Hooks > Scheduler
Amazon SP API settings

## Is there any existing behavior change of other features due to this code change?
Yes. Hourly scheduler won't work at midnight and state mapping is now optional

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
