### PR TITLE
fix: extended timeout of daily scheduler

### DIFF
--- a/eseller_suite/hooks.py
+++ b/eseller_suite/hooks.py
@@ -143,7 +143,7 @@ scheduler_events = {
 # 	"all": [
 # 		"eseller_suite.tasks.all"
 # 	],
-	"daily": [
+	"daily_long": [
 		"eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_sp_api_settings.schedule_get_order_details_daily"
 	],
 	"hourly": [


### PR DESCRIPTION
## Issue description
Daily scheduler getting timed out

## Solution description
Changed the daily scheduled task from daily scheduler to daily long scheduler (300s timeout to 1500s timeout)

## Output screenshots
![image](https://github.com/user-attachments/assets/351eab90-7b0d-49b1-919e-025e90c6caf3)

## Areas affected and ensured
Scheduler

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
