### PR TITLE
fix: handling timezone difference and scheduler timeout

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
@@ -8,6 +8,7 @@ import frappe
 from frappe import _
 from frappe.model.document import Document
 from frappe.utils import add_days, getdate, now_datetime, today
+import pytz
 
 
 class AmazonSPAPISettings(Document):
@@ -78,7 +79,14 @@ def schedule_get_order_details():
 		get_orders,
 	)
 
-	current_date = getdate().strftime("%Y-%m-%d")
+	system_timezone = frappe.db.get_single_value("System Settings", "time_zone")
+
+	local_tz = pytz.timezone(system_timezone)
+	gmt_tz = pytz.timezone("GMT")
+
+	local_datetime = local_tz.localize(current_datetime)
+	gmt_datetime = local_datetime.astimezone(gmt_tz)
+	current_date = gmt_datetime.strftime("%Y-%m-%d")
 
 	amz_settings = frappe.get_all(
 		"Amazon SP API Settings",

--- a/eseller_suite/hooks.py
+++ b/eseller_suite/hooks.py
@@ -146,7 +146,7 @@ scheduler_events = {
 	"daily_long": [
 		"eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_sp_api_settings.schedule_get_order_details_daily"
 	],
-	"hourly": [
+	"hourly_long": [
 		"eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_sp_api_settings.schedule_get_order_details",
 	],
 # 	"weekly": [


### PR DESCRIPTION
## Issue description
Currently, Amazon orders are fetched based on GMT time (+00:00), but since we're using Indian Standard Time (IST, +05:30) for syncing, this time difference was causing some orders to be missed. Need to implement a solution to handle the timezone difference more accurately
Hourly Scheduler getting timed out

## Solution description
Converted current time in the system to GMT + 0 time 
Changed Hourly scheduler to Hourly Long scheduler

## Areas affected and ensured
Hourly Scheduler for syncing amazon data

## Is there any existing behavior change of other features due to this code 
Yes, the hourly scheduler will now adjust the date depending on system timezone

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
