### PR TITLE
Amz payment entry chore

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -200,6 +200,27 @@ class AmazonPaymentEntry(Document):
 					jv_row.debit = abs(float(row.total))
 					jv_row.debit_in_account_currency = abs(float(row.total))
 					total_debit += abs(float(row.total))
+			elif frappe.db.get_single_value("eSeller Settings", "use_reserve_lines_in_amazon_payment_entry"):
+				reserve_jv_row = jv_doc.append('accounts')
+				reserve_jv_row.user_remark = row.product_details
+				if float(row.total) > 0:
+					reserve_jv_row.account = frappe.db.get_single_value("eSeller Settings", "amazon_reserve_income_account")
+					reserve_jv_row.credit = abs(float(row.total))
+					reserve_jv_row.credit_in_account_currency = abs(float(row.total))
+					total_credit += abs(float(row.total))
+				else:
+					reserve_jv_row.account = frappe.db.get_single_value("eSeller Settings", "amazon_reserve_expense_account")
+					jv_row.debit = abs(float(row.total))
+					jv_row.debit_in_account_currency = abs(float(row.total))
+					total_debit += abs(float(row.total))
+				if row.order_id:
+					reserve_jv_row.amazon_order_id = row.order_id
+				if row.customer:
+					reserve_jv_row.party_type = 'Customer'
+					reserve_jv_row.party = row.customer
+
+
+
 		difference_amount = total_debit-total_credit
 		jv_row = jv_doc.append('accounts')
 		jv_row.account = self.payment_account

--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -648,16 +648,6 @@ class AmazonRepository:
 						})
 						frappe.db.set_value("Sales Invoice Item", {"parent": si, "item_code": actual_item}, "refunded", 1)
 						return_created = True
-					elif frappe.db.exists("Sales Invoice Item", {"parent": si, "item_code": item.get('item_code'), "refunded":0 }):
-						return_si.append("items", {
-							"item_code": item.get('item_code'),
-							"qty": -1 * float(item.get('qty')),
-							"rate": abs(float(item.get('amount'))/float(item.get('qty'))),
-							"sales_order": so_id,
-							"sales_invoice_item": frappe.db.get_value("Sales Invoice Item", {"parent": si, "item_code": item.get('item_code')}, "name")
-						})
-						frappe.db.set_value("Sales Invoice Item", {"parent": si, "item_code": item.get('item_code')}, "refunded", 1)
-						return_created = True
 
 				if return_created:
 					for charge in refund.get("charges", []):

--- a/eseller_suite/eseller_suite/doctype/eseller_settings/eseller_settings.json
+++ b/eseller_suite/eseller_suite/doctype/eseller_settings/eseller_settings.json
@@ -12,6 +12,9 @@
   "column_break_lzak",
   "amazon_reserve_fund",
   "inventory_reimbursement_account",
+  "use_reserve_lines_in_amazon_payment_entry",
+  "amazon_reserve_income_account",
+  "amazon_reserve_expense_account",
   "default_pos_profile",
   "flipkart_defaults_section",
   "default_flipkart_customer",
@@ -102,13 +105,35 @@
    "label": "Inventory Reimbursement Account",
    "options": "Account",
    "reqd": 1
+  },
+  {
+   "depends_on": "eval: doc.use_reserve_lines_in_amazon_payment_entry",
+   "fieldname": "amazon_reserve_income_account",
+   "fieldtype": "Link",
+   "label": "Amazon Reserve Income Account",
+   "mandatory_depends_on": "eval: doc.use_reserve_lines_in_amazon_payment_entry",
+   "options": "Account"
+  },
+  {
+   "depends_on": "eval: doc.use_reserve_lines_in_amazon_payment_entry",
+   "fieldname": "amazon_reserve_expense_account",
+   "fieldtype": "Link",
+   "label": "Amazon Reserve Expense Account",
+   "mandatory_depends_on": "eval: doc.use_reserve_lines_in_amazon_payment_entry",
+   "options": "Account"
+  },
+  {
+   "default": "0",
+   "fieldname": "use_reserve_lines_in_amazon_payment_entry",
+   "fieldtype": "Check",
+   "label": "Use Reserve Lines in Amazon Payment Entry"
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2024-11-07 11:04:08.789659",
+ "modified": "2024-12-12 10:10:00.016588",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "eSeller Settings",


### PR DESCRIPTION
## Feature description
- Added an option to record unreferenced Income and Expenses in Amazon Payment Entry
- Added exception handling when saving and submitting a sales order, as well as creating a return invoice
- Changed the code of creating return invoice to use actual item

## Areas affected and ensured
- Amazon Payment Entry

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
