### PR TITLE
fix: empty check in duplicates validation

### DIFF
--- a/eseller_suite/eseller_suite/custom_script/purchase_receipt/purchase_receipt.py
+++ b/eseller_suite/eseller_suite/custom_script/purchase_receipt/purchase_receipt.py
@@ -134,7 +134,6 @@ def activate_barcodes(doc, method=None):
                     alert=True,
                 )
 
-
 def find_duplicates(lst):
     seen = set()
     duplicates = set()
@@ -143,4 +142,5 @@ def find_duplicates(lst):
             duplicates.add(item)
         else:
             seen.add(item)
-    return list(duplicates)
+    cleaned_duplicates = [item for item in duplicates if item.strip()]
+    return cleaned_duplicates


### PR DESCRIPTION
## Feature description
Duplicates validation triggering on empty inputs

## Solution description
Removed empty data from the duplicates list

## Areas affected and ensured
Purchase Receipt custom script

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
