### PR TITLE
fix: zero debit or credit in amz payment entry

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -210,8 +210,8 @@ class AmazonPaymentEntry(Document):
 					total_credit += abs(float(row.total))
 				else:
 					reserve_jv_row.account = frappe.db.get_single_value("eSeller Settings", "amazon_reserve_expense_account")
-					jv_row.debit = abs(float(row.total))
-					jv_row.debit_in_account_currency = abs(float(row.total))
+					reserve_jv_row.debit = abs(float(row.total))
+					reserve_jv_row.debit_in_account_currency = abs(float(row.total))
 					total_debit += abs(float(row.total))
 				if row.order_id:
 					reserve_jv_row.amazon_order_id = row.order_id


### PR DESCRIPTION
## Issue description
Cannot submit amazon payment entry to create JV. The error being shown s that one row in the created JV has zero credit or debit.

## Solution description
The Reserve row update for JV was not updated properly

## Areas affected and ensured
Amazon Payment Entry

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
