### PR TITLE
feat: moving stock to temporary and amazon sales report optimization

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -782,7 +782,6 @@ class AmazonRepository:
 			so.custom_validate()
 			if so.grand_total>=0:
 				try:
-					self.create_temporary_stock_transfer(so)
 					so.save(ignore_permissions=True)
 				except Exception as e:
 					frappe.log_error("Error saving Sales Order for Order {0}".format(so.amazon_order_id), e, "Sales Order")
@@ -880,23 +879,6 @@ class AmazonRepository:
 
 	def get_catalog_items_instance(self) -> CatalogItems:
 		return CatalogItems(**self.instance_params)
-
-	def create_temporary_stock_transfer(self, so):
-		temp_stock_entry = frappe.new_doc("Stock Entry")
-		temp_stock_entry.stock_entry_type = "Material Transfer"
-		warehouse = self.amz_setting.warehouse
-		if so.fulfillment_channel:
-			if so.fulfillment_channel=='AFN':
-				warehouse = self.amz_setting.afn_warehouse
-		for item in so.items:
-			temp_stock_entry.append("items", {
-				"s_warehouse": warehouse,
-				"t_warehouse": self.amz_setting.temporary_order_warehouse,
-				"item_code": item.item_code,
-				"qty": item.qty
-			})
-		temp_stock_entry.insert(ignore_permissions=True)
-		temp_stock_entry.submit()
 
 def get_orders(amz_setting_name, last_updated_after, sync_selected_date_only=0) -> list:
 	ar = AmazonRepository(amz_setting_name)

--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -14,6 +14,7 @@
   "refresh_token",
   "section_break_2",
   "company",
+  "temporary_order_warehouse",
   "warehouse",
   "afn_warehouse",
   "parent_item_group",
@@ -228,10 +229,17 @@
    "fieldname": "map_state_data",
    "fieldtype": "Check",
    "label": "Map State Data"
+  },
+  {
+   "fieldname": "temporary_order_warehouse",
+   "fieldtype": "Link",
+   "label": "Temporary Order Warehouse",
+   "options": "Warehouse",
+   "reqd": 1
   }
  ],
  "links": [],
- "modified": "2024-12-02 16:12:58.741537",
+ "modified": "2025-01-23 16:20:56.305111",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon SP API Settings",

--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.py
@@ -7,7 +7,7 @@ from datetime import datetime, timedelta
 import frappe
 from frappe import _
 from frappe.model.document import Document
-from frappe.utils import add_days, getdate, now_datetime, today
+from frappe.utils import add_days, getdate, now_datetime, today, get_date_str
 import pytz
 
 
@@ -31,7 +31,7 @@ class AmazonSPAPISettings(Document):
 
 	def validate_after_date(self):
 		if datetime.strptime(add_days(today(), -30), "%Y-%m-%d") > datetime.strptime(
-			self.after_date, "%Y-%m-%d"
+			get_date_str(self.after_date), "%Y-%m-%d"
 		):
 			frappe.throw(_("The date must be within the last 30 days."))
 

--- a/eseller_suite/eseller_suite/report/amazon_sales_report/amazon_sales_report.json
+++ b/eseller_suite/eseller_suite/report/amazon_sales_report/amazon_sales_report.json
@@ -9,7 +9,7 @@
  "idx": 0,
  "is_standard": "Yes",
  "letterhead": null,
- "modified": "2024-09-10 10:27:48.211323",
+ "modified": "2025-01-24 15:16:08.103018",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon Sales Report",

--- a/eseller_suite/setup.py
+++ b/eseller_suite/setup.py
@@ -158,7 +158,17 @@ def get_sales_order_custom_fields():
 				"label": "Transaction Time",
 				"insert_after": "transaction_date",
 				"no_copy": 1,
-			}
+			},
+			{
+				"fieldname": "temporary_stock_tranfer_id",
+				"fieldtype": "Link",
+				"label": "Temporary Stock Transfer ID",
+				"insert_after": "fulfillment_channel",
+				"read_only": 1,
+				"no_copy": 1,
+				"options": "Stock Entry",
+				"depends_on": "eval:frappe.session.user=='Administrator'"
+			},
 		],
 		"Sales Order Item": [
 			{


### PR DESCRIPTION
## Feature description
When a Sales Order is created via amazon sync, items are moved to a warehouse set in Amazon SP API Settings and the source warehouse in the sales order is set to the same
Optimized Amazon Sales Report

## Areas affected and ensured
Amazon SP API Settings

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox - Yes
  - Opera Mini
  - Safari
