### PR TITLE
feat: handling other income and cancellation charges in amz payment e…

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.js
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.js
@@ -8,6 +8,7 @@ frappe.ui.form.on("Amazon Payment Entry", {
                 frm.set_value('mode_of_payment', default_mode_of_payment);
             });
         }
+        frm.set_df_property('payment_details', 'cannot_add_rows', true)
     },
     refresh(frm) {
         if (frm.doc.in_progress) {

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.json
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.json
@@ -38,8 +38,7 @@
    "fieldname": "payment_details",
    "fieldtype": "Table",
    "label": "Payment Details",
-   "options": "Amazon Payment Entry Item",
-   "read_only": 1
+   "options": "Amazon Payment Entry Item"
   },
   {
    "fieldname": "column_break_isbj",
@@ -119,7 +118,7 @@
    "link_fieldname": "cheque_no"
   }
  ],
- "modified": "2024-11-12 11:38:43.448822",
+ "modified": "2025-03-07 12:15:51.305353",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon Payment Entry",

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -167,7 +167,6 @@ class AmazonPaymentEntry(Document):
 							row.amazon_expense_account = other_income_account
 							has_changes = True
 				if row.transaction_type.strip() == 'Cancellation' and row.product_details == 'Order Cancellation Charge' and row.total and row.order_id:
-					print("are we here??")
 					if float(row.total) < 0:
 						order_cancellation_account = frappe.db.get_single_value('eSeller Settings', 'order_cancellation_account')
 						if order_cancellation_account:

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -160,6 +160,20 @@ class AmazonPaymentEntry(Document):
 							row.ready_to_process = 1
 							row.amazon_expense_account = other_expenses_account
 							has_changes = True
+					elif float(row.total) > 0:
+						other_income_account = frappe.db.get_single_value('eSeller Settings', 'other_income_account')
+						if other_income_account:
+							row.ready_to_process = 1
+							row.amazon_expense_account = other_income_account
+							has_changes = True
+				if row.transaction_type.strip() == 'Cancellation' and row.product_details == 'Order Cancellation Charge' and row.total and row.order_id:
+					print("are we here??")
+					if float(row.total) < 0:
+						order_cancellation_account = frappe.db.get_single_value('eSeller Settings', 'order_cancellation_account')
+						if order_cancellation_account:
+							row.ready_to_process = 1
+							row.amazon_expense_account = order_cancellation_account
+							has_changes = True
 		if has_changes:
 			self.save()
 		return 1

--- a/eseller_suite/eseller_suite/doctype/eseller_settings/eseller_settings.json
+++ b/eseller_suite/eseller_suite/doctype/eseller_settings/eseller_settings.json
@@ -9,15 +9,20 @@
   "default_mode_of_payment",
   "max_invoice_count",
   "default_amazon_customer",
+  "column_break_psuc",
+  "default_pos_profile",
+  "amazon_payment_entry_accounts_section",
   "column_break_lzak",
   "amazon_reserve_fund",
   "inventory_reimbursement_account",
   "inventory_reimbursement_income_account",
+  "other_income_account",
+  "column_break_icux",
   "other_expenses_account",
+  "order_cancellation_account",
   "use_reserve_lines_in_amazon_payment_entry",
   "amazon_reserve_income_account",
   "amazon_reserve_expense_account",
-  "default_pos_profile",
   "flipkart_defaults_section",
   "default_flipkart_customer",
   "column_break_qzmo",
@@ -145,13 +150,42 @@
    "label": "Other Expenses Account",
    "options": "Account",
    "reqd": 1
+  },
+  {
+   "description": "This account will be used for Other Income",
+   "fieldname": "other_income_account",
+   "fieldtype": "Link",
+   "label": "Other Income Account",
+   "options": "Account",
+   "reqd": 1
+  },
+  {
+   "description": "This account will be used for Expenses against Order cancellation (will not be booked against the order)",
+   "fieldname": "order_cancellation_account",
+   "fieldtype": "Link",
+   "label": "Order Cancellation Account",
+   "options": "Account",
+   "reqd": 1
+  },
+  {
+   "fieldname": "column_break_psuc",
+   "fieldtype": "Column Break"
+  },
+  {
+   "fieldname": "amazon_payment_entry_accounts_section",
+   "fieldtype": "Section Break",
+   "label": "Amazon Payment Entry Accounts"
+  },
+  {
+   "fieldname": "column_break_icux",
+   "fieldtype": "Column Break"
   }
  ],
  "hide_toolbar": 1,
  "index_web_pages_for_search": 1,
  "issingle": 1,
  "links": [],
- "modified": "2025-03-06 15:44:02.827689",
+ "modified": "2025-03-07 10:16:09.129485",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "eSeller Settings",


### PR DESCRIPTION
…ntry

## Feature description
Handle the following in Amazon Payment Entry:-
- Order Cancellation Charges
- Other Income

## Output screenshots
![image](https://github.com/user-attachments/assets/134e5f4b-ce9e-4a0d-940c-e81b38307d17)

## Areas affected and ensured
Amazon Payment Entry
eSeller Settings

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
