### PR TITLE
chore: check for taxes and charges before submitting so

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -830,7 +830,7 @@ class AmazonRepository:
 					"Unfulfillable",
 				]
 
-				if order.get("OrderStatus") in order_statuses:
+				if order.get("OrderStatus") in order_statuses and len(so.taxes):
 					try:
 						so.submit()
 					except Exception as e:


### PR DESCRIPTION
## Feature description
Should check for existence of Taxes and Charges before submitting an so and si being created.

## Solution description
checked the data before so submission is done

## Areas affected and ensured
Amazon SO sync

## Is there any existing behavior change of other features due to this code change?
Yes, sales orders without taxes and charges will not be submitted.

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
