### PR TITLE
handling partial cancelled orders, amazon easy ship charges return marked on return invoice

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -98,7 +98,7 @@ class AmazonPaymentEntry(Document):
 					invoice_details = get_invoice_details(row.order_id, is_return=0)
 					return_invoice_details = None
 					is_return = False
-					if row.transaction_type in ['Fulfillment Fee Refund', 'Refund']:
+					if row.transaction_type in ['Fulfillment Fee Refund', 'Refund'] or row.product_details == 'Weight Handling Fees Reversal':
 						is_return = True
 						return_invoice_details = get_invoice_details(row.order_id, is_return=1)
 					if invoice_details.get('sales_invoice'):

--- a/eseller_suite/eseller_suite/doctype/cancelled_order_items/cancelled_order_items.json
+++ b/eseller_suite/eseller_suite/doctype/cancelled_order_items/cancelled_order_items.json
@@ -1,0 +1,40 @@
+{
+ "actions": [],
+ "allow_rename": 1,
+ "creation": "2025-04-05 15:38:04.393614",
+ "doctype": "DocType",
+ "editable_grid": 1,
+ "engine": "InnoDB",
+ "field_order": [
+  "cancelled_item_code",
+  "cancelled_item_qty"
+ ],
+ "fields": [
+  {
+   "fieldname": "cancelled_item_code",
+   "fieldtype": "Link",
+   "in_list_view": 1,
+   "label": "Cancelled Item Code",
+   "options": "Item"
+  },
+  {
+   "fieldname": "cancelled_item_qty",
+   "fieldtype": "Int",
+   "in_list_view": 1,
+   "label": "Cancelled Item Qty"
+  }
+ ],
+ "grid_page_length": 50,
+ "index_web_pages_for_search": 1,
+ "istable": 1,
+ "links": [],
+ "modified": "2025-04-05 15:41:53.742504",
+ "modified_by": "Administrator",
+ "module": "eSeller Suite",
+ "name": "Cancelled Order Items",
+ "owner": "Administrator",
+ "permissions": [],
+ "sort_field": "modified",
+ "sort_order": "DESC",
+ "states": []
+}

--- a/eseller_suite/eseller_suite/doctype/cancelled_order_items/cancelled_order_items.py
+++ b/eseller_suite/eseller_suite/doctype/cancelled_order_items/cancelled_order_items.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025, efeone and contributors
+# For license information, please see license.txt
+
+# import frappe
+from frappe.model.document import Document
+
+
+class CancelledOrderItems(Document):
+	pass

--- a/eseller_suite/setup.py
+++ b/eseller_suite/setup.py
@@ -179,6 +179,15 @@ def get_sales_order_custom_fields():
 				"options": "Stock Entry",
 				"depends_on": "eval:frappe.session.user=='Administrator'"
 			},
+			{
+				"fieldname": "cancelled_items",
+				"fieldtype": "Table",
+				"label": "Cancelled Items",
+				"insert_after": "items",
+				"read_only": 1,
+				"no_copy": 1,
+				"options": "Cancelled Order Items",
+			}
 		],
 		"Sales Order Item": [
 			{


### PR DESCRIPTION
## Feature description
When some (not all) items in an order is cancelled, it has to be recorded as cancelled separately

## Solution description
Unlike fully cancelled orders, cancelled items in an order will not be recorded in Cacnelled Items table in Sales Order

## Output screenshots 
![image](https://github.com/user-attachments/assets/5ae5c228-bfa1-4ce1-a92a-e12156653a2e)


## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
