### PR TITLE
Delete serial nos

### DIFF
--- a/eseller_suite/eseller_suite/custom_script/purchase_receipt/purchase_receipt.py
+++ b/eseller_suite/eseller_suite/custom_script/purchase_receipt/purchase_receipt.py
@@ -147,3 +147,23 @@ def find_duplicates(lst):
             seen.add(item)
     cleaned_duplicates = [item for item in duplicates if item.strip()]
     return cleaned_duplicates
+
+def delete_barcodes(doc, method=None):
+    """
+    Delete barcodes from the purchase receipt.
+    """
+    for item in doc.items:
+        if not item.barcode_no:
+            continue
+
+        barcodes = item.barcode_no.split("\n")
+        for barcode in barcodes:
+            if not barcode:
+                continue
+            existing_serial_no = frappe.db.exists(
+                "eSeller Serial No",
+                {"serial_no": barcode, "purchase_document_no": doc.name},
+            )
+            if existing_serial_no:
+                serial_doc = frappe.get_doc("eSeller Serial No", existing_serial_no)
+                serial_doc.delete()

--- a/eseller_suite/eseller_suite/custom_script/purchase_receipt/purchase_receipt.py
+++ b/eseller_suite/eseller_suite/custom_script/purchase_receipt/purchase_receipt.py
@@ -15,6 +15,8 @@ def create_barcodes(doc, method=None):
     if not company:
         frappe.throw("Company default is not set. Please configure your defaults.")
 
+    serial_numbers_processed = False
+
     for item in doc.items:
         if not item.barcode_no:
             continue
@@ -97,16 +99,18 @@ def create_barcodes(doc, method=None):
             serial_no.insert(ignore_permissions=True)
 
             qty += 1
+            serial_numbers_processed = True
 
         item.qty = qty
         if doc.doctype == "Purchase Receipt":
             item.received_qty = qty
 
-    frappe.msgprint(
-        msg="Serial Numbers Processed.",
-        alert=True,
-        indicator="green"
-    )
+    if serial_numbers_processed:
+        frappe.msgprint(
+            msg="Serial Numbers Processed.",
+            alert=True,
+            indicator="green"
+        )
 
 
 def activate_barcodes(doc, method=None):
@@ -116,6 +120,8 @@ def activate_barcodes(doc, method=None):
         doc (_type_): _description_
         method (_type_, optional): _description_. Defaults to None.
     """
+    serial_numbers_activated = False
+
     for item in doc.items:
         if not item.barcode_no:
             continue
@@ -131,10 +137,13 @@ def activate_barcodes(doc, method=None):
                 serial_doc.status = "Active"
                 serial_doc.warehouse = item.warehouse
                 serial_doc.save()
-    frappe.msgprint(
-        "Serial Numbers are now Active",
-        alert=True,
-    )
+                serial_numbers_activated = True
+
+    if serial_numbers_activated:
+        frappe.msgprint(
+            "Serial Numbers are now Active",
+            alert=True,
+        )
 
 
 def find_duplicates(lst):

--- a/eseller_suite/eseller_suite/doctype/eseller_serial_no/eseller_serial_no.json
+++ b/eseller_suite/eseller_suite/doctype/eseller_serial_no/eseller_serial_no.json
@@ -166,12 +166,14 @@
    "fetch_from": "transfer_document_no.posting_date",
    "fieldname": "transfer_date",
    "fieldtype": "Date",
-   "label": "Transfer Date"
+   "label": "Transfer Date",
+   "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2024-12-18 16:19:45.157682",
+ "modified": "2025-04-17 11:37:32.075727",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "eSeller Serial No",
@@ -191,6 +193,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/eseller_suite/hooks.py
+++ b/eseller_suite/hooks.py
@@ -136,6 +136,7 @@ doc_events = {
 	'Purchase Receipt':{
 		"before_validate": "eseller_suite.eseller_suite.custom_script.purchase_receipt.purchase_receipt.create_barcodes",
 		"before_submit": "eseller_suite.eseller_suite.custom_script.purchase_receipt.purchase_receipt.activate_barcodes",
+		"on_cancel": "eseller_suite.eseller_suite.custom_script.purchase_receipt.purchase_receipt.delete_barcodes",
 	},
 	'Stock Entry':{
 		"before_validate": "eseller_suite.eseller_suite.custom_script.purchase_receipt.purchase_receipt.create_barcodes",


### PR DESCRIPTION
## Feature description
Serial Nos should be deleted when a PR is cancelled

## Chore description
Cleaned up the alert messages to only appear when needed

## Areas affected and ensured
eSeller Serial No. Updation

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome
  - Mozilla Firefox
  - Opera Mini
  - Safari
