### PR TITLE
fix: stock issues due to temporary transfers

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.json
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.json
@@ -38,6 +38,7 @@
    "fieldname": "payment_details",
    "fieldtype": "Table",
    "label": "Payment Details",
+   "no_copy": 1,
    "options": "Amazon Payment Entry Item"
   },
   {
@@ -107,9 +108,11 @@
    "fieldtype": "Check",
    "hidden": 1,
    "label": "In Progress",
+   "no_copy": 1,
    "read_only": 1
   }
  ],
+ "grid_page_length": 50,
  "index_web_pages_for_search": 1,
  "is_submittable": 1,
  "links": [
@@ -118,7 +121,7 @@
    "link_fieldname": "cheque_no"
   }
  ],
- "modified": "2025-03-07 12:15:51.305353",
+ "modified": "2025-05-19 13:00:51.221508",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon Payment Entry",
@@ -138,6 +141,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": []

--- a/eseller_suite/patches.txt
+++ b/eseller_suite/patches.txt
@@ -4,3 +4,4 @@
 
 [post_model_sync]
 # Patches added in this section will be executed after doctypes are migrated
+eseller_suite.patches.delete_unlinked_temporary_stock_tranfers #19/05/2024

--- a/eseller_suite/patches/delete_unlinked_temporary_stock_tranfers.py
+++ b/eseller_suite/patches/delete_unlinked_temporary_stock_tranfers.py
@@ -1,0 +1,43 @@
+import frappe
+
+
+def execute():
+    print("Deleting unlinked temporary stock transfers...")
+
+    frappe.db.set_value("Stock Settings", "Stock Settings", "allow_negative_stock", 1)
+
+    is_negative_stock_allowed = frappe.db.get_single_value("Stock Settings", "allow_negative_stock")
+
+    if not is_negative_stock_allowed:
+        print("Negative stock is not allowed. Exiting.")
+        return
+    
+    query = """
+        SELECT se.name
+        FROM `tabStock Entry` AS se
+        LEFT JOIN `tabStock Entry Detail` AS sed ON sed.parent = se.name
+        WHERE sed.t_warehouse = %s
+        AND se.name NOT IN (
+            SELECT temporary_stock_tranfer_id
+            FROM `tabSales Order`
+            WHERE temporary_stock_tranfer_id IS NOT NULL
+        )
+    """
+
+    warehouse = "Temporary warehouse  - HEL"
+
+    # Fetch as list of tuples, then extract just the names
+    results = frappe.db.sql(query, (warehouse,), as_list=True)
+    names = [row[0] for row in results]
+
+    for name in names:
+        print(f"Cancelling & Deleting stock entry: {name}")
+        se_doc = frappe.get_doc("Stock Entry", name)
+        se_doc.flags.ignore_validate = True
+        se_doc.cancel()
+        frappe.delete_doc("Stock Entry", name)
+        print(f"Deleted stock entry: {name}")
+
+    frappe.db.set_value("Stock Settings", "Stock Settings", "allow_negative_stock", 0)
+    
+    print("Unlinked temporary stock transfers deleted successfully.")


### PR DESCRIPTION
## Issue description
Major stock inconsistencies caused by temporary stock transfer

## Solution description
- Patch to delete unlinked temporary stock transfers
- Confirmation for temporary stock transfer before so submission
- Deleting temporary stock transfers after deletion of corresponding sales orders
- Warehouses in Returns should be based on the fulfillment channel

## Areas affected and ensured
Amazon Repository

## Is there any existing behavior change of other features due to this code change?
No

## Was this feature tested on the browsers?
  - Chrome - Yes
  - Mozilla Firefox
  - Opera Mini
  - Safari
