### PR TITLE
fix: links missing for replaced order references in amz payment entry

### DIFF
--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.js
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.js
@@ -64,7 +64,7 @@ function handle_custom_buttons(frm) {
             // Button for debug purposes only for Administrator
             if (frappe.session.user == "Administrator") {
                 frm.add_custom_button('Unset Ready to Process', () => {
-                    unsert_ready_to_process(frm);
+                    unset_ready_to_process(frm);
                 }, 'Fetch');
             }
         }
@@ -131,7 +131,7 @@ function get_missing_sales_orders(frm) {
 /**
  * function to uncheck ready to process checks in all the lines in the table
  */
-function unsert_ready_to_process(frm) {
+function unset_ready_to_process(frm) {
     frm.call({
         method: "unset_ready_to_process",
         doc: frm.doc,

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.js
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.js
@@ -60,6 +60,13 @@ function handle_custom_buttons(frm) {
             frm.add_custom_button('Missing Sales Orders', () => {
                 get_missing_sales_orders(frm);
             }, 'Fetch');
+
+            // Button for debug purposes only for Administrator
+            if (frappe.session.user == "Administrator") {
+                frm.add_custom_button('Unset Ready to Process', () => {
+                    unsert_ready_to_process(frm);
+                }, 'Fetch');
+            }
         }
     }
 }
@@ -113,6 +120,27 @@ function get_missing_sales_orders(frm) {
             if (r && r.message) {
                 frappe.show_alert({
                     message: __('Sales Orders created/updated successfully'),
+                    indicator: 'green'
+                }, 5);
+            }
+            frm.reload_doc();
+        }
+    });
+}
+
+/**
+ * function to uncheck ready to process checks in all the lines in the table
+ */
+function unsert_ready_to_process(frm) {
+    frm.call({
+        method: "unset_ready_to_process",
+        doc: frm.doc,
+        freeze: true,
+        freeze_message: __("Removing Ready to Process.."),
+        callback: (r) => {
+            if (r && r.message) {
+                frappe.show_alert({
+                    message: __('Ready to Process removed successfully'),
                     indicator: 'green'
                 }, 5);
             }


### PR DESCRIPTION
## Reason for PR
Missing Customer and Sales Invoice links for Ready to Process lines in Amazon Payment Entry. This was due to Invoices and SOs being deleted but the JVs of replaced orders being left behind.

## Changes Made
Added button to unset ready to process so the invoices can be fetched again. 
Updated invoicing fetching code to ensure customer and sales invoice IDs are set