### PR TITLE
March sync issue2

### DIFF
--- a/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
+++ b/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
@@ -60,7 +60,10 @@ class SalesOrderOverride(SalesOrder):
 		if self.amazon_order_status == "Canceled" and self.temporary_stock_tranfer_id:
 			if frappe.db.exists("Stock Entry", {"name":self.temporary_stock_tranfer_id, "docstatus":["!=", 2]}):
 				temp_stock_transfer_doc = frappe.get_doc("Stock Entry", self.temporary_stock_tranfer_id)
+				self.temporary_stock_tranfer_id = ""
+				self.save(ignore_permissions=True)
 				temp_stock_transfer_doc.cancel()
+				temp_stock_transfer_doc.delete()
 
 	def after_insert(self):
 		amz_setting = frappe.get_last_doc("Amazon SP API Settings", {"is_active":1})

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.json
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.json
@@ -16,6 +16,8 @@
   "company",
   "default_receivable_account",
   "amazon_reserve_fund_account",
+  "fetch_customizations_section",
+  "remaining_refunds_have_no_returns",
   "payment_details_section",
   "payment_details",
   "amended_from"
@@ -110,6 +112,18 @@
    "label": "In Progress",
    "no_copy": 1,
    "read_only": 1
+  },
+  {
+   "collapsible": 1,
+   "fieldname": "fetch_customizations_section",
+   "fieldtype": "Section Break",
+   "label": "Fetch Customizations"
+  },
+  {
+   "default": "0",
+   "fieldname": "remaining_refunds_have_no_returns",
+   "fieldtype": "Check",
+   "label": "Remaining Refunds have no Returns"
   }
  ],
  "grid_page_length": 50,
@@ -121,7 +135,7 @@
    "link_fieldname": "cheque_no"
   }
  ],
- "modified": "2025-05-19 13:00:51.221508",
+ "modified": "2025-05-27 22:35:46.809548",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon Payment Entry",

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -113,6 +113,9 @@ class AmazonPaymentEntry(Document):
 							row.return_sales_invoice = return_invoice_details.get('sales_invoice')
 							row.ready_to_process = 1
 							has_changes = True
+					elif not return_invoice_details and self.remaining_refunds_have_no_returns:
+						row.ready_to_process = 1
+						has_changes = True
 				elif row.transaction_type in ["Unavailable balance", "Previous statement's unavailable balance"]:
 					row.ready_to_process = 1
 					has_changes = True
@@ -193,6 +196,8 @@ class AmazonPaymentEntry(Document):
 		total_credit = 0
 		for row in self.payment_details:
 			if row.ready_to_process and row.total:
+				if row.total == 0:
+					continue
 				jv_row = jv_doc.append('accounts')
 				if row.transaction_type in ["Previous statement's unavailable balance", "Unavailable balance"]:
 					jv_row.account = self.amazon_reserve_fund_account

--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -577,11 +577,14 @@ class AmazonRepository:
 							
 							if float(amount) != 0:
 								fee_account = self.get_account(fee_type)
+								description = (
+									f"{fee_type} for {seller_sku if seller_sku else order_id}"
+								)
 								charges_and_fees["fees"].append({
 									"charge_type": "Actual",
 									"account_head": fee_account,
 									"tax_amount": amount,
-									"description": fee_type + " for " + seller_sku,
+									"description": description,
 								})
 						
 						refund_events.append(charges_and_fees)		
@@ -610,16 +613,18 @@ class AmazonRepository:
 								
 								if float(amount) != 0:
 									tds_account = self.get_account(tds_type)
+									description = (
+										f"{fee_type} for {seller_sku if seller_sku else order_id}"
+									)
 									charges_and_fees["tds"].append({
 										"charge_type": "Actual",
 										"account_head": tds_account,
 										"tax_amount": amount,
-										"description": tds_type + " for " + seller_sku,
+										"description": description,
 									})
 						
 						refund_events.append(charges_and_fees)			
 
-				# Remove the redundant line that was causing duplicate appending
 				refund_events.append(charges_and_fees)
 
 				if not next_token:
@@ -947,10 +952,8 @@ class AmazonRepository:
 
 				if order_status_valid and has_taxes and transfer_exists:
 					try:
-						print("Submitting SO: ", so.name)
 						so.submit()
 					except Exception as e:
-						print("Oops: ", e)
 						frappe.log_error("Error submitting Sales Order for Order {0}".format(so.amazon_order_id), e, "Sales Order")
 			elif not frappe.db.exists("Amazon Failed Sync Record", {"amazon_order_id":order_id}):
 				remarks = 'Failed to create Sales Order for {0}. Sales Order grand Total = {1}'.format(order_id, so.grand_total)

--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_repository.py
@@ -892,7 +892,8 @@ class AmazonRepository:
 				if not refunds:
 					for service_fee in charges_and_fees.get("service_fees"):
 						if service_fee:
-							if not service_fee.get("account_head") == "Amazon MFNPostageFee - HEL":
+							mfn_postage_fee_account_head = frappe.db.get_value('Amazon SP API Settings', self.amz_setting.name, 'mfn_postage_fee_account_head')
+							if not service_fee.get("account_head") == mfn_postage_fee_account_head:
 								so.append("taxes", service_fee)
 							else:
 								try:

--- a/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
+++ b/eseller_suite/eseller_suite/doctype/amazon_sp_api_settings/amazon_sp_api_settings.json
@@ -25,6 +25,7 @@
   "territory",
   "customer_type",
   "market_place_account_group",
+  "mfn_postage_fee_account_head",
   "section_break_3",
   "after_date",
   "taxes_charges",
@@ -260,10 +261,17 @@
    "fieldtype": "Date",
    "label": "Return Invoice Stock Adjustment Before",
    "mandatory_depends_on": "eval: doc.adjust_stock_for_returns"
+  },
+  {
+   "fieldname": "mfn_postage_fee_account_head",
+   "fieldtype": "Link",
+   "label": "MFN Postage Fee Account Head",
+   "options": "Account",
+   "reqd": 1
   }
  ],
  "links": [],
- "modified": "2025-02-20 11:47:42.068266",
+ "modified": "2025-05-28 11:37:39.301083",
  "modified_by": "Administrator",
  "module": "eSeller Suite",
  "name": "Amazon SP API Settings",
@@ -280,6 +288,7 @@
    "write": 1
   }
  ],
+ "row_format": "Dynamic",
  "sort_field": "modified",
  "sort_order": "DESC",
  "states": [],


### PR DESCRIPTION
## Reason for PR
- Temporary Stock Transfer Cancellation on order cancel status causing link issues
- Need to handle:
- - Refunds without Returns in amz payment entry
- - mfn postage fee in amz payment entry
- issue with concatenation in sync

## Changes Made
- Updated script to remove link before cancelling and deleting the temporary stock transfer
- Added an option to set all remaining refunds in the amz payment entry to be set as ready to process
- created a separate jv for mfn postage fees
- updated script to handle none values in concatenation
- other mining fixes