### PR TITLE
fix: added validation for amz so submission

### DIFF
--- a/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
+++ b/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
@@ -3,11 +3,12 @@ from erpnext.accounts.party import get_party_account
 from erpnext.selling.doctype.sales_order.sales_order import SalesOrder
 from erpnext.setup.doctype.item_group.item_group import get_item_group_defaults
 from erpnext.stock.doctype.item.item import get_item_defaults
+from erpnext.stock.stock_ledger import get_stock_balance
+from frappe import _
 from frappe.contacts.doctype.address.address import get_company_address
 from frappe.model.mapper import get_mapped_doc
 from frappe.model.utils import get_fetch_values
 from frappe.utils import cint, flt
-from erpnext.stock.stock_ledger import get_stock_balance
 
 
 class SalesOrderOverride(SalesOrder):
@@ -79,6 +80,9 @@ class SalesOrderOverride(SalesOrder):
 					temp_stock_transfer_doc.cancel()
 				temp_stock_transfer_doc.delete()
 
+	def before_submit(self):
+		self.validate_amazon_so_submit()
+
 	def create_temporary_stock_transfer(self):
 		"""method creates a stock entry to the temporary warehoue when a sales order is screated
 		"""
@@ -112,6 +116,38 @@ class SalesOrderOverride(SalesOrder):
 			failed_sync_record.amazon_order_id = self.amazon_order_id
 			failed_sync_record.remarks = "Failed to create temporary stock entry\n" + str(e)
 			failed_sync_record.save(ignore_permissions=True)
+
+	def validate_amazon_so_submit(self):
+		"""method validates the amazon sales order"""
+		order_statuses = [
+			"Shipped",
+			"InvoiceUnconfirmed",
+			"Unfulfillable",
+		]
+
+		order_status_valid = self.amazon_order_status in order_statuses
+		has_taxes = len(self.taxes) > 0
+
+		transfer_flag = True
+		if self.temporary_stock_tranfer_id:
+			transfer_flag = frappe.db.exists("Stock Entry", {
+				"name": self.temporary_stock_tranfer_id,
+				"docstatus": 1
+			})
+
+		if not (order_status_valid and has_taxes and transfer_flag):
+			msg = f"Sales Order {self.name} cannot be submitted."
+			if not order_status_valid:
+				msg += " Ensure that the order status is valid."
+			if order_status_valid and not has_taxes:
+				msg += " Ensure that taxes are set for the order."
+			if order_status_valid and not transfer_flag:
+				msg += " Ensure that the temporary stock transfer has been completed."
+			frappe.throw(
+				_(msg),
+				title=_("Invalid Sales Order Submission"),
+				exc=frappe.ValidationError
+			)
 
 @frappe.whitelist()
 def make_sales_invoice(source_name, target_doc=None, ignore_permissions=False):

--- a/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
+++ b/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
@@ -81,7 +81,8 @@ class SalesOrderOverride(SalesOrder):
 				temp_stock_transfer_doc.delete()
 
 	def before_submit(self):
-		self.validate_amazon_so_submit()
+		if self.amazon_order_id:
+			self.validate_amazon_so_submit()
 
 	def create_temporary_stock_transfer(self):
 		"""method creates a stock entry to the temporary warehoue when a sales order is screated

--- a/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
+++ b/eseller_suite/eseller_suite/doctype/amazon_payment_entry/amazon_payment_entry.py
@@ -1,15 +1,19 @@
 # Copyright (c) 2024, efeone and contributors
 # For license information, please see license.txt
 
-import os
 import csv
-import xlrd
-import frappe
+import os
 from datetime import datetime
+
+import frappe
+from charset_normalizer import from_path
 from frappe.model.document import Document
 from frappe.utils import get_link_to_form, get_url_to_form
-from eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_repository import get_order
-from charset_normalizer import from_path
+
+from eseller_suite.eseller_suite.doctype.amazon_sp_api_settings.amazon_repository import (
+	get_order,
+)
+
 
 class AmazonPaymentEntry(Document):
 	def before_save(self):
@@ -21,7 +25,10 @@ class AmazonPaymentEntry(Document):
 			if row.return_sales_invoice:
 				if frappe.db.get_value('Sales Invoice', row.return_sales_invoice, 'docstatus') == 2:
 					row.return_sales_invoice = ''
-     
+			if row.sales_invoice:
+				if frappe.db.get_value('Sales Invoice', row.sales_invoice, 'docstatus') == 2:
+					row.sales_invoice = ''
+	 
 	def validate(self):
 		if not self.payment_details:
 			self.process_payment_data()


### PR DESCRIPTION
## Reason for PR
- Bulk submission of sales orders caused orders that should not be submitted to be submitted as well.

## Changes Made
- Added validation to ensure only valid amazon sales orders can be submitted
- Added script to ensure cancelled sales invoices won't be linked in an amazon payment entry