### PR TITLE
fix: cancel stock transfer only if submitted against so

### DIFF
--- a/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
+++ b/eseller_suite/eseller_suite/custom_script/sales_order/sales_order.py
@@ -63,7 +63,8 @@ class SalesOrderOverride(SalesOrder):
 				temp_stock_transfer_doc = frappe.get_doc("Stock Entry", self.temporary_stock_tranfer_id)
 				self.temporary_stock_tranfer_id = ""
 				self.save(ignore_permissions=True)
-				temp_stock_transfer_doc.cancel()
+				if temp_stock_transfer_doc.docstatus == 1:
+					temp_stock_transfer_doc.cancel()
 				temp_stock_transfer_doc.delete()
 
 	def after_insert(self):


### PR DESCRIPTION
## Reason for PR
- Sync trying to cancel unsubmitted stock entries

## Changes Made
- Cancel only if the stock entry is submitted